### PR TITLE
Remove Download from Launcher

### DIFF
--- a/ui/AndroidManifest.xml
+++ b/ui/AndroidManifest.xml
@@ -18,7 +18,6 @@
             android:theme="@android:style/Theme.NoDisplay">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW_DOWNLOADS" />


### PR DESCRIPTION
* This is redundant because DocumentsUI already has Downloads inside it.  No reason to be redundant.

Signed-off-by: Chet Kener <Cl3Kener@gmail.com>